### PR TITLE
Fix missing Kotlin dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
@@ -39,4 +40,10 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.20.+'
+}
+
+allprojects {
+    repositories {
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
+    }
 }


### PR DESCRIPTION
This fixes the following two build errors:

Could not find org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.60-eap-25.
Could not find org.jetbrains.kotlin:kotlin-reflect:1.3.60-eap-25.